### PR TITLE
Fixes the permanent scrollbar of the website

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -17,6 +17,8 @@ body {
     flex-flow: row wrap;
     justify-content: space-evenly;
     align-items: center;
+    margin: 0;
+    padding: 0;
 }
 
 #text {


### PR DESCRIPTION
There was permanent scrollbar visible on the page. The reason behind that was that the "height: 100%;" rule of the body actually makes a page bigger than that because, by default, browsers add a 8px margin to all sides of a page which get added to the 100%.

Also removing potential paddings.